### PR TITLE
Name posters as "poster.jpg"

### DIFF
--- a/various/poster_downloader.py
+++ b/various/poster_downloader.py
@@ -16,6 +16,7 @@ plex_api_token = ''
 
 from os import getenv
 from os.path import splitext
+import re
 
 # Environmental Variables
 plex_ip = getenv('plex_ip', plex_ip)
@@ -28,7 +29,7 @@ def _download_poster(ssn, media_info: dict):
 
 	if 'thumb' in media_info and 'Media' in media_info:
 		poster = ssn.get(f'{base_url}{media_info["thumb"]}').content
-		file_path = splitext(media_info['Media'][0]['Part'][0]['file'])[0] + '.jpg'
+		file_path = re.sub(r"[^\\]+\\?$", "poster.jpg", splitext(media_info['Media'][0]['Part'][0]['file'])[0])
 		with open(file_path, 'wb') as f:
 			f.write(poster)
 


### PR DESCRIPTION
Original script makes the poster file name based on the movie/show file name which IMO is a bad idea because it is always subject to changes (upgraded movie/tv file ex). Of course this would be better as a command line option to toggle on or off or customize the default name but I didn't need that for my use case. In the article below by Plex, they list a number of default names that posters can have.

https://support.plex.tv/articles/200220677-local-media-assets-movies/