### PR TITLE
Add new Plex python script to change subtitle settings for all movies and shows in library to "prefer non-forced subtitles"

### DIFF
--- a/changing_settings/PlexPreferNonForcedSubs.py
+++ b/changing_settings/PlexPreferNonForcedSubs.py
@@ -1,0 +1,64 @@
+from plexapi.server import PlexServer
+import requests
+import xml.etree.ElementTree as ET
+#import pdb             //enable for debugging
+#pdb.set_trace()       //insert where to start debugging, press n to proceed to next line
+
+#This python script will set all movies and shows in your local Plex library to English non forced subtitles by default. The subtitle selections will apply to your Plex profile and be remembered on other devices.
+
+# Connect to the Plex server
+baseurl = 'http://localhost:32400'
+token = 'xxxxxxxx'
+plex = PlexServer(baseurl, token)
+
+
+# Set all movies to use English non-forced subtitles if available, otherwise print no subtitles found
+for movie in plex.library.section('Movies').all():
+    movie.reload()
+    english_subs = [stream for stream in movie.subtitleStreams() if stream.languageCode == 'eng']
+    non_forced_english_subs = [stream for stream in english_subs if not stream.forced]
+    forced_english_subs = [stream for stream in english_subs if stream.forced]
+    part = movie.media[0].parts[0]
+    partsid = part.id
+    if forced_english_subs and non_forced_english_subs:
+        # If movies has forced english subs AND non forced english subs THEN set show to prefer english non forced subs
+        # Send a request to the Plex client to set the subtitle stream
+        url = f'{baseurl}/library/parts/{partsid}?subtitleStreamID={non_forced_english_subs[0].id}&allParts=1'
+        headers = {'X-Plex-Token': token}
+        requests.put(url, headers=headers)
+        print(f'{movie.title}: Setting non forced English subtitles.')
+    elif non_forced_english_subs and not forced_english_subs:
+        print(f'{movie.title}: Has english subtitles but no english forced subtitles. No subtitle changes.')
+    elif not non_forced_english_subs and not forced_english_subs and not forced_english_subs:
+        print(f'{movie.title}: No English subtitles found. No subtitle changes.')
+    else:
+        print(f'{movie.title}: No subtitle changes.')
+
+
+# Set all TV shows to use English non-forced subtitles if available, otherwise print no subtitles found
+for show in plex.library.section('TV Shows').all():
+    show.reload()
+    for episode in show.episodes():
+        show.reload()
+        episode.reload()
+        english_subs = [stream for stream in episode.subtitleStreams() if stream.languageCode == 'eng']
+        non_forced_english_subs = [stream for stream in english_subs if not stream.forced]
+        forced_english_subs = [stream for stream in english_subs if stream.forced]
+        part = episode.media[0].parts[0]
+        partsid = part.id
+        if forced_english_subs and non_forced_english_subs:
+            # If show has forced english subs AND non forced english subs THEN set show to prefer english non forced subs
+            # Send a request to the Plex client to set the subtitle stream
+            url = f'{baseurl}/library/parts/{partsid}?subtitleStreamID={non_forced_english_subs[0].id}&allParts=1'
+            headers = {'X-Plex-Token': token}
+            requests.put(url, headers=headers)
+            print(f'{show.title} - {episode.title}: Setting non forced English subtitles.')
+        elif non_forced_english_subs and not forced_english_subs:
+            print(f'{show.title} - {episode.title}: Has english subtitles but no english forecd subtitles. No subtitle changes.')
+        elif not non_forced_english_subs and not forced_english_subs and not forced_english_subs:
+            print(f'{show.title} - {episode.title}: No English subtitles found. No subtitle changes.')
+        else:
+            print(f'{show.title} - {episode.title}: No subtitle changes.')
+
+
+input("Press [Enter] to continue.")      #//enable to stop window from closing on completion


### PR DESCRIPTION
# PlexPreferNonForcedSubs.py


## Short description:
This python script will set all movies and shows in your local Plex library to English non forced subtitles by default. The subtitle selections will apply to your Plex profile and be remembered on other devices.

## Long description:
This script was created with the help of [ChatGPT Open AI](https://chat.openai.com/chat) and further edited and completed by me. It uses [Plex Python Api](https://python-plexapi.readthedocs.io/en/latest/). It will set all movies and shows in your local Plex library to English non forced subtitles by default. The subtitle selections will apply to your Plex profile and be remembered on other devices. Assuming your Plex subtitles settings are setup in your server settings Plex will default to Forced Subtitles by default when they are available for a given item. Plex will not allow you to prefer non forced subtitles natively hence why this script was created.

This script is confirmed tested and working. Feel free to use this code for your own purposes. Thanks to [all](https://stackoverflow.com/questions/75027919/python-script-to-set-all-subtitles-for-movies-shows-in-plex-to-english-non-for) who helped! If you use this script and run into any bugs feel free to open an issue. Cheers!

## Known issues/future outlook:
* Forced subs without the "forced" tag will be treated as non forced subs. This [could be fixed](https://python-plexapi.readthedocs.io/en/latest/modules/media.html#plexapi.media.MediaPart) in the script by checking the subtitle "title" tag for some variation of the word "forced". 
* [Python-PlexAPI](https://python-plexapi.readthedocs.io/en/latest/modules/media.html#plexapi.media.MediaPart.setDefaultSubtitleStream) has a method to set the default subtitle stream. No need to manually call the API using requests. 
* Several lines of redundant code can be shorted and/or removed
* Plans to print out neat colored data tables when the script runs

## What are "non-forced" subtitles?
Non-forced subtitles provide subtitles everytime a characters speaks.

## What are "forced" subtitles?
Forced subtitles only provide subtitles when the characters speak a foreign or alien language.


## Instructions:
##### Windows:
To use this script on Windows. Simply install latest version of [Python](https://www.python.org/downloads/). 
1. Download the latest PlexPreferNonForcedSubs.py script. 
2. Replace xxxxxxx in the script with your [plex api token](https://www.plexopedia.com/plex-media-server/general/plex-token/).
3. Make sure Plex media server is running locally then run the script and watch it work its magic.

##### Note:
This script should work fine on any other operating system. No need to make any changes.


## Also posted on:
* [Github](https://github.com/RileyXX/PlexPreferNonForcedSubs)
* [Stackoverflow](https://stackoverflow.com/q/75027919/9196825)
* [Reddit](https://www.reddit.com/r/PleX/comments/105gdh7/python_code_to_set_all_movies_and_shows_in_plex/)
* [Plex Forums](https://forums.plex.tv/t/python-script-to-set-all-movies-and-shows-in-plex-to-use-english-non-forced-subtitles/825871)

## Screenshots:
##### Plex subtitle dropdown after script is done running:
![Plex Subtitle Dropdown](https://i.imgur.com/BNOlwtL.png)
##### PlexPreferNonForcedSubs.py script in action:
![PlexPreferNonForcedSubs.py Script in Action](https://i.imgur.com/2l6DuU6.png)

