### PR TITLE
m3u_to_playlist.py: Add basic ability to import relative file paths

### DIFF
--- a/playlist_collection/m3u_to_playlist.py
+++ b/playlist_collection/m3u_to_playlist.py
@@ -30,7 +30,7 @@ from os import path
 plex_ip = getenv('plex_ip', plex_ip)
 plex_port = getenv('plex_port', plex_port)
 plex_api_token = getenv('plex_api_token', plex_api_token)
-base_url = f"https://{plex_ip}:{plex_port}"
+base_url = f"http://{plex_ip}:{plex_port}"
 
 def m3u_to_playlist(ssn, library_name: str, file_path: str, users: list=['@me'], library_path: str=''):
 	# Check for illegal arg parsing

--- a/playlist_collection/m3u_to_playlist.py
+++ b/playlist_collection/m3u_to_playlist.py
@@ -8,6 +8,15 @@ Requirements (python3 -m pip install [requirement]):
 	requests
 Setup:
 	Fill the variables below firstly, then run the script with -h to see the arguments that you need to give.
+
+Use with relative file path M3U files:
+	- The script assumes the .m3u file is placed at the root of the music folder.
+	- open the terminal from the folder with your music (and where the .m3u file is placed)
+	- run the script with the additional argument "--LibraryPath" including the path of the files within Plex to your music library.
+	Example:
+	linux: python3 ./m3u_to_playlist.py -l "Music" -f "chill.m3u" -u @all -p /media/Music/
+	windows: python .\m3u_to_playlist.py -l "Music" -f "chill.m3u" -u @all -p /media/Music/
+
 """
 
 plex_ip = ''
@@ -21,9 +30,9 @@ from os import path
 plex_ip = getenv('plex_ip', plex_ip)
 plex_port = getenv('plex_port', plex_port)
 plex_api_token = getenv('plex_api_token', plex_api_token)
-base_url = f"http://{plex_ip}:{plex_port}"
+base_url = f"https://{plex_ip}:{plex_port}"
 
-def m3u_to_playlist(ssn, library_name: str, file_path: str, users: list=['@me']):
+def m3u_to_playlist(ssn, library_name: str, file_path: str, users: list=['@me'], library_path: str=''):
 	# Check for illegal arg parsing
 	if not path.isfile(file_path):
 		return 'File not found'
@@ -41,7 +50,7 @@ def m3u_to_playlist(ssn, library_name: str, file_path: str, users: list=['@me'])
 	for lib in sections:
 		if lib['title'] == library_name:
 			for user_token in user_data.values():
-				ssn.post(f'{base_url}/playlists/upload', params={'sectionID': lib['key'], 'path': file_path, 'X-Plex-Token': user_token})
+				ssn.post(f'{base_url}/playlists/upload', params={'sectionID': lib['key'], 'path': library_path+file_path, 'X-Plex-Token': user_token})
 			return
 
 	return 'Library not found'
@@ -58,11 +67,12 @@ if __name__ == '__main__':
 	# Setup arg parsing
 	parser = ArgumentParser(description='Convert a .m3u file to a plex playlist')
 	parser.add_argument('-l','--LibraryName', type=str, help='Name of target library', required=True)
+	parser.add_argument('-p','--LibraryPath', type=str, help='Path within Plex to the Music files. Make sure it ends with /.', default='', required=False)
 	parser.add_argument('-f','--File', type=str, help="File path to the .m3u file", required=True)
 	parser.add_argument('-u','--User', help='Apply user-specific sync actions to these users; This argument can be given multiple times; Use @me to target yourself; Use @all to target everyone', action='append', default=['@me'])
 
 	args = parser.parse_args()
 	# Call function and process result
-	response = m3u_to_playlist(ssn=ssn, library_name=args.LibraryName, file_path=args.File, users=args.User)
+	response = m3u_to_playlist(ssn=ssn, library_name=args.LibraryName, file_path=args.File, users=args.User, library_path=args.LibraryPath)
 	if response is not None:
 		parser.error(response)


### PR DESCRIPTION
Hello :)
I do not know if you are interested in pull requests. Feel free to ignore if not.

My m3u files contain relative file paths and I run Plex on a dedicated computer, meaning the absolute paths to the music files are different between my computer and on the Plex machine.

I slightly modified the file to be able to deal with this situation. The modification is optional and does not change anything if the file is used in the intended way.

I've added an optional `LibraryPath` argument that provides the script with the relative path to the m3u file within the Plex folder structure. This is then concatenated with the file name in the URL and allows Plex to find the file within its different folder structure. If the argument is not provided, the string stays empty and the concatenation has no effect, keeping the script as it was before.

This only works when the .m3u file sits at the root of the music folder within Plex (and the script is also executed from that location), which are acceptable compromises to avoid heavy modifications of the script, I think.

Warm regards,

Jicka